### PR TITLE
WIP Expanding Runtime Polyfill to <3.10

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ module.exports = {
   included() {
     this._super.included.apply(this, arguments);
 
-    if (!this.shouldPolyfill) {
+    if (!this.shouldPolyfillBuiltinComponents) {
       return;
     }
 
@@ -115,7 +115,7 @@ module.exports = {
   },
 
   treeForVendor(rawVendorTree) {
-    if (!this.shouldPolyfill) {
+    if (!this.shouldPolyfillBuiltinComponents) {
       return;
     }
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-named-arguments-polyfill": "^1.0.0",
     "ember-resolver": "^4.0.0",
-    "ember-source": "~3.2.0-beta.2",
+    "ember-source": "~3.4.0",
     "ember-source-channel-url": "^1.0.1",
     "ember-try": "^0.2.23",
     "eslint": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3090,10 +3090,10 @@ ember-source-channel-url@^1.0.1:
   dependencies:
     got "^8.0.1"
 
-ember-source@~3.2.0-beta.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.2.2.tgz#f1b899beeb838b0866a66cd327d22e567abd8a79"
-  integrity sha512-mnzfA/XaCPEblGGOIgS0UDirbo/cR2xsSYxiPCtvX2gOymX4/6JQ/cjh/7P8z+ylveMOR6BG5CHb3SLm4IdXJw==
+ember-source@~3.4.0:
+  version "3.4.8"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.4.8.tgz#68677bf9bd222aff865100b241004649c3d3dda7"
+  integrity sha512-uiRqAzzFKvZ0P5zf5eOv2BrhBUNFJOnsUrri6dN8Ci7pxBkj/fyKVxwIu/+juQh4E/QRgrfze/+Cueq0FNf6rQ==
   dependencies:
     broccoli-funnel "^2.0.1"
     broccoli-merge-trees "^2.0.0"
@@ -6928,10 +6928,17 @@ resolve@1.5.0:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.3.0, resolve@^1.3.3, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.8.1:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.3.0, resolve@^1.3.3, resolve@^1.5.0, resolve@^1.8.1:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
   integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.6.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
+  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
   dependencies:
     path-parse "^1.0.6"
 


### PR DESCRIPTION
Status:

* Expanded polyfill to run against built-ins for the full range of the polyfill
* Doesn't work in 3.4-3.9 because the component `ast-transform` doesn't run in `gte(3.4.0-beta.1)`, thus the parent components don't have an `__ANGLE_ATTRS__` property to pass in the attr applied externally (e.g. `<FooBar data-test-foo/>`
* We need to figure out how to get information on the component's angle attributes in Glimmer VM 0.35 and 0.37, either by conditionally grabbing the information from somewhere other than `__ANGLE_ATTRS__` when the child is rendered or finding a way to extract that information during the parent's rendering process via a lightweight wrapper around the real angle bracket implementation.